### PR TITLE
BugFixes in compose and entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,12 @@ then
   mkdir /etc/netatalk
 fi
 
+if [ ! -d "/var/netatalk/CNID" ]
+then
+  mkdir /var/netatalk/CNID
+fi
+
+
 # write afp.conf if CUSTOM_AFP_CONF is not true
 if [ "${CUSTOM_AFP_CONF}" != "true" ]
 then

--- a/timemachine-compose.yml
+++ b/timemachine-compose.yml
@@ -3,19 +3,19 @@ services:
   timemachine:
     network_mode: "host"
     environment:
-      - CUSTOM_AFP_CONF="false"
-      - LOG_LEVEL="info"
-      - MIMIC_MODEL="TimeCapsule6,106"
-      - PASSWORD="timemachine"
-      - SET_PERMISSIONS="false"
-      - SHARE_NAME="TimeMachine"
-      - VOLUME_SIZE_LIMIT="0"
+      - CUSTOM_AFP_CONF=false
+      - LOG_LEVEL=info
+      - MIMIC_MODEL=TimeCapsule6,106
+      - PASSWORD=timemachine
+      - SET_PERMISSIONS=false
+      - SHARE_NAME=TimeMachine
+      - VOLUME_SIZE_LIMIT=0
     restart: unless-stopped
     ports:
      - "548:548"
      - "636:636"
     volumes:
-     - /mnt/backups/timemachine:/timemachine
+     - /path/to/your/timemachine/volume:/timemachine
      - ./timemachine-netatalk:/var/netatalk
      - ./timemachine-logs:/var/log/supervisor
     ulimits:


### PR DESCRIPTION

1.  environment variables in compose file should not contain ""
2. netatalk failed to initialize CNID database. 
    cnid_metad[15] {cnid_metad.c:321} (error:CNID): set_dbdir: mkdir failed for /var/netatalk/CNID//TimeMachine/
 