### PR TITLE
Add fruit:metadata option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ docker run -d --restart=always \
   -e SHARE_NAME="TimeMachine" \
   -e SMB_INHERIT_PERMISSIONS="no" \
   -e SMB_NFS_ACES="yes" \
+  -e SMB_METADATA="stream" \
   -e SMB_PORT="445" \
   -e SMB_VFS_OBJECTS="acl_xattr fruit streams_xattr" \
   -e VOLUME_SIZE_LIMIT="0" \
@@ -72,6 +73,7 @@ docker run -d --restart=always \
   -e SHARE_NAME="TimeMachine" \
   -e SMB_INHERIT_PERMISSIONS="no" \
   -e SMB_NFS_ACES="yes" \
+  -e SMB_METADATA="stream" \
   -e SMB_PORT="445" \
   -e SMB_VFS_OBJECTS="acl_xattr fruit streams_xattr" \
   -e VOLUME_SIZE_LIMIT="0" \
@@ -112,24 +114,24 @@ __Note__: If you are already running Samba on your Docker host (or you're wantin
 
 ```
 services:
-timemachine:
-  hostname: timemachine
-  mac_address: "AA:BB:CC:DD:EE:FF"
-  networks:
-    timemachine:
-      ipv4_address: 192.168.1.x
+  timemachine:
+    hostname: timemachine
+    mac_address: "AA:BB:CC:DD:EE:FF"
+    networks:
+      timemachine:
+        ipv4_address: 192.168.1.x
 
 networks:
-timemachine:
-  driver: macvlan
-  driver_opts:
-    parent: eth0
-  ipam:
-    config:
-      - subnet: 192.168.1.0/24
-        ip_range: 192.168.1.0/24
-        gateway: 192.168.1.1
-```
+  timemachine:
+    driver: macvlan
+    driver_opts:
+      parent: eth0
+    ipam:
+      config:
+        - subnet: 192.168.1.0/24
+          ip_range: 192.168.1.0/24
+          gateway: 192.168.1.1
+  ```
 
 1. `hostname`, `mac_address`, and `ipv4_address` are optional, but can be used to control how it is configured on the network. If not defined, random values will be used.
 2. This config requires [docker-compose version](https://docs.docker.com/compose/compose-file/) `1.27.0+` which implements the [compse specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md).
@@ -164,6 +166,7 @@ Default credentials:
 | `SHARE_NAME` | `TimeMachine` | sets the name of the timemachine share to TimeMachine by default |
 | `SMB_INHERIT_PERMISSIONS` | `no` | if yes, permissions for new files will be forced to match the parent folder |
 | `SMB_NFS_ACES` | `yes` | value of `fruit:nfs_aces`; support for querying and modifying the UNIX mode of directory entries via NFS ACEs |
+| `SMB_METADATA` | `stream` | value of `fruit:metadata`; controls where the OS X metadata stream is stored |
 | `SMB_PORT` | `445` | sets the port that Samba will be available on |
 | `SMB_VFS_OBJECTS` | `acl_xattr fruit streams_xattr` | value of `vfs objects` |
 | `VOLUME_SIZE_LIMIT` | `0` | sets the maximum size of the time machine backup; a unit can also be passed (e.g. - `1 T`). See the [Samba docs](https://www.samba.org/samba/docs/current/man-html/vfs_fruit.8.html) under the `fruit:time machine max size` section for more details |
@@ -214,6 +217,7 @@ docker run -d --restart=always \
   -e SHARE_NAME="TimeMachine" \
   -e SMB_INHERIT_PERMISSIONS="no" \
   -e SMB_NFS_ACES="yes" \
+  -e SMB_METADATA="stream" \
   -e SMB_PORT="445" \
   -e SMB_VFS_OBJECTS="acl_xattr fruit streams_xattr" \
   -e VOLUME_SIZE_LIMIT="0" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,7 @@ HIDE_SHARES="${HIDE_SHARES:-no}"
 SMB_VFS_OBJECTS="${SMB_VFS_OBJECTS:-acl_xattr fruit streams_xattr}"
 SMB_INHERIT_PERMISSIONS="${SMB_INHERIT_PERMISSIONS:-no}"
 SMB_NFS_ACES="${SMB_NFS_ACES:-yes}"
+SMB_METADATA="${SMB_METADATA:-stream}"
 
 # common functions
 password_var_or_file() {
@@ -147,16 +148,13 @@ create_smb_user() {
     echo "INFO: CUSTOM_SMB_CONF=false; generating [${SHARE_NAME}] section of /etc/samba/smb.conf..."
     echo "
 [${SHARE_NAME}]
-   fruit:aapl = yes
-   fruit:time machine = yes
-   fruit:time machine max size = ${VOLUME_SIZE_LIMIT}
-   fruit:nfs_aces = ${SMB_NFS_ACES}
    path = /opt/${TM_USERNAME}
    inherit permissions = ${SMB_INHERIT_PERMISSIONS}
+   read only = no
    valid users = ${TM_USERNAME}
-   browseable = yes
-   writable = yes
-   vfs objects = ${SMB_VFS_OBJECTS}" >> /etc/samba/smb.conf
+   vfs objects = ${SMB_VFS_OBJECTS}
+   fruit:time machine = yes
+   fruit:time machine max size = ${VOLUME_SIZE_LIMIT}" >> /etc/samba/smb.conf
   else
     # CUSTOM_SMB_CONF was specified; make sure the file exists
     if [ -f "/etc/samba/smb.conf" ]
@@ -217,27 +215,27 @@ then
   then
     echo "INFO: CUSTOM_SMB_CONF=false; generating [global] section of /etc/samba/smb.conf..."
     echo "[global]
-   min protocol = SMB2
-   server role = standalone server
-   workgroup = ${WORKGROUP}
-   smb ports = ${SMB_PORT}
-   #unix password sync = yes
+   access based share enum = ${HIDE_SHARES}
+   hide unreadable = ${HIDE_SHARES}
+   inherit permissions = ${SMB_INHERIT_PERMISSIONS}
+   load printers = no
    log file = /var/log/samba/log.%m
    logging = file
    max log size = 1000
    security = user
-   load printers = no
-   inherit permissions = ${SMB_INHERIT_PERMISSIONS}
-   access based share enum = ${HIDE_SHARES}
-   hide unreadable = ${HIDE_SHARES}
+   server min protocol = SMB2
+   server role = standalone server
+   smb ports = ${SMB_PORT}
+   workgroup = ${WORKGROUP}
    vfs objects = ${SMB_VFS_OBJECTS}
-   fruit:delete_empty_adfiles = yes
-   fruit:metadata = stream
-   fruit:model = ${MIMIC_MODEL}
+   fruit:aapl = yes
    fruit:nfs_aces = ${SMB_NFS_ACES}
-   fruit:posix_rename = yes
+   fruit:model = ${MIMIC_MODEL}
+   fruit:metadata = ${SMB_METADATA}
    fruit:veto_appledouble = no
-   fruit:wipe_intentionally_left_blank_rfork = yes" > /etc/samba/smb.conf
+   fruit:posix_rename = yes
+   fruit:wipe_intentionally_left_blank_rfork = yes
+   fruit:delete_empty_adfiles = yes" > /etc/samba/smb.conf
   fi
 
   # mkdir if needed

--- a/timemachine-compose-smb-arm7l.yml
+++ b/timemachine-compose-smb-arm7l.yml
@@ -21,7 +21,8 @@ services:
       - SET_PERMISSIONS=false
       - SHARE_NAME=TimeMachine
       - SMB_INHERIT_PERMISSIONS=no
-      - SMB_NFS_ACES=yes
+      - SMB_NFS_ACES=no
+      - SMB_METADATA=stream
       - SMB_PORT=445
       - SMB_VFS_OBJECTS=acl_xattr fruit streams_xattr
       - VOLUME_SIZE_LIMIT=0

--- a/timemachine-compose-smb-arm7l.yml
+++ b/timemachine-compose-smb-arm7l.yml
@@ -21,7 +21,7 @@ services:
       - SET_PERMISSIONS=false
       - SHARE_NAME=TimeMachine
       - SMB_INHERIT_PERMISSIONS=no
-      - SMB_NFS_ACES=no
+      - SMB_NFS_ACES=yes
       - SMB_METADATA=stream
       - SMB_PORT=445
       - SMB_VFS_OBJECTS=acl_xattr fruit streams_xattr

--- a/timemachine-compose-smb.yml
+++ b/timemachine-compose-smb.yml
@@ -18,6 +18,7 @@ services:
       - SHARE_NAME=TimeMachine
       - SMB_INHERIT_PERMISSIONS=no
       - SMB_NFS_ACES=yes
+      - SMB_METADATA=stream
       - SMB_PORT=445
       - SMB_VFS_OBJECTS=acl_xattr fruit streams_xattr
       - VOLUME_SIZE_LIMIT=0


### PR DESCRIPTION
This started out as a test for some TM issues that I was having with one of my Macs. I added a new option to test changing a setting. But that didn't fix my issue. In the end, there didn't seem to be a fix for that issue (I think it may be something with that particular Mac and not this image).

But along the way I went through all the smb settings. There shouldn't be any functional changes to any of the defaults. It mainly involved making sure the settings were in the right section, removing defaults to make it more obvious what was being overridden, and organization. The settings were all verified with the smb docs and with `testparm` in the running container.

The only change that seemed to make any difference in my testing was overriding the `SMB_NFS_ACES` to no.