### PR TITLE
Samba 4.15 changes

### DIFF
--- a/s6/nmbd/run
+++ b/s6/nmbd/run
@@ -2,4 +2,4 @@
 
 DEBUG_LEVEL="${DEBUG_LEVEL:-1}"
 
-exec /usr/sbin/nmbd --foreground --no-process-group --log-stdout --debuglevel="${DEBUG_LEVEL}" < /dev/null
+exec /usr/sbin/nmbd --foreground --no-process-group --debug-stdout --debuglevel="${DEBUG_LEVEL}" < /dev/null

--- a/s6/smbd/run
+++ b/s6/smbd/run
@@ -2,4 +2,4 @@
 
 DEBUG_LEVEL="${DEBUG_LEVEL:-1}"
 
-exec /usr/sbin/smbd --foreground --no-process-group --log-stdout --debuglevel="${DEBUG_LEVEL}" < /dev/null
+exec /usr/sbin/smbd --foreground --no-process-group --debug-stdout --debuglevel="${DEBUG_LEVEL}" < /dev/null


### PR DESCRIPTION
See https://www.samba.org/samba/history/samba-4.15.0.html

smbd and nmbd in version 4.15 removed `--log-stdout` and replaced it with `--debug-stdout`.

Looks like upstream `alpine:latest` image updated samba version and this causes newer builds of this image to break.