### PR TITLE
mkdir for dbus; fixes #130 & #131

### DIFF
--- a/Dockerfile.smb
+++ b/Dockerfile.smb
@@ -6,7 +6,8 @@ LABEL maintainer="Matt Bentley <mbentley@mbentley.net>"
 RUN apk add --no-cache attr avahi avahi-compat-libdns_sd avahi-tools dbus samba-common-tools s6 samba-server &&\
   touch /etc/samba/lmhosts &&\
   rm /etc/samba/smb.conf &&\
-  rm /etc/avahi/services/*.service
+  rm /etc/avahi/services/*.service &&\
+  mkdir /var/run/dbus
 
 # copy in necessary supporting config files
 COPY s6 /etc/s6


### PR DESCRIPTION
Alpine 3.18 broke this; this works around the dbus directory not existing & not being able to be created.