### PR TITLE
feat: add EXTRA_SHARE env vars for non-Time Machine shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,40 @@ If you change the `TM_USERNAME` value, it will change the persistent data path f
 | `VOLUME_SIZE_LIMIT` | `0` | sets the maximum size of the time machine backup; a unit can also be passed (e.g. - `1 T`). See the [Samba docs](https://www.samba.org/samba/docs/current/man-html/vfs_fruit.8.html) under the `fruit:time machine max size` section for more details |
 | `WORKGROUP` | `WORKGROUP` | set the Samba workgroup name |
 | `IGNORE_DOS_ATTRIBUTES` | `false` | If set to `true` Samba will ignore DOS attributes. This is accomplished by setting [store dos attributes](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#STOREDOSATTRIBUTES), [map hidden](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPHIDDEN), [map system](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPSYSTEM), [map archive](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPARCHIVE) and [map readonly](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPREADONLY) to `no` in the `[global]` section. |
+| `EXTRA_SHARE_<N>_NAME` | _not set_ | Name of an additional non-Time Machine share (N starts at 1); only used in single-user mode (not with `EXTERNAL_CONF`) |
+| `EXTRA_SHARE_<N>_PATH` | _not set_ | Path for the additional share identified by `EXTRA_SHARE_<N>_NAME` |
+
+### Adding Extra Non-Time Machine Shares (without EXTERNAL_CONF)
+
+If you want to expose one or more regular file shares alongside your Time Machine share, you can use the `EXTRA_SHARE_<N>_NAME` and `EXTRA_SHARE_<N>_PATH` environment variables instead of setting up `EXTERNAL_CONF` files. This is especially useful for container orchestrators (Portainer, Runtipi, etc.) where shipping config files alongside the container is awkward.
+
+The numbering starts at 1 and must be sequential (the loop stops at the first missing `_NAME`).
+
+#### Example docker-compose with an extra share
+
+```yaml
+services:
+  timemachine:
+    image: mbentley/timemachine:smb
+    network_mode: host
+    environment:
+      - TM_USERNAME=timemachine
+      - PASSWORD=timemachine
+      - SHARE_NAME=TimeMachine
+      - VOLUME_SIZE_LIMIT=512000
+      - EXTRA_SHARE_1_NAME=Files
+      - EXTRA_SHARE_1_PATH=/opt/files
+    volumes:
+      - /path/to/timemachine:/opt/timemachine
+      - /path/to/files:/opt/files
+    tmpfs:
+      - /run/samba
+    restart: unless-stopped
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+```
 
 ### Adding Multiple Users & Shares
 

--- a/README.md
+++ b/README.md
@@ -218,17 +218,17 @@ If you change the `TM_USERNAME` value, it will change the persistent data path f
 | `SMB_METADATA` | `stream` | value of `fruit:metadata`; controls where the OS X metadata stream is stored |
 | `SMB_PORT` | `445` | sets the port that Samba will be available on |
 | `SMB_VFS_OBJECTS` | `fruit streams_xattr` | value of `vfs objects` |
-| `VOLUME_SIZE_LIMIT` | `0` | sets the maximum size of the time machine backup; a unit can also be passed (e.g. - `1 T`). See the [Samba docs](https://www.samba.org/samba/docs/current/man-html/vfs_fruit.8.html) under the `fruit:time machine max size` section for more details |
+| `VOLUME_SIZE_LIMIT` | `0` | sets the maximum size of the time machine backup in MiB; a unit can also be passed (e.g. - `1 T`). See the [Samba docs](https://www.samba.org/samba/docs/current/man-html/vfs_fruit.8.html) under the `fruit:time machine max size` section for more details |
 | `WORKGROUP` | `WORKGROUP` | set the Samba workgroup name |
 | `IGNORE_DOS_ATTRIBUTES` | `false` | If set to `true` Samba will ignore DOS attributes. This is accomplished by setting [store dos attributes](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#STOREDOSATTRIBUTES), [map hidden](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPHIDDEN), [map system](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPSYSTEM), [map archive](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPARCHIVE) and [map readonly](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPREADONLY) to `no` in the `[global]` section. |
-| `EXTRA_SHARE_<N>_NAME` | _not set_ | Name of an additional non-Time Machine share (N starts at 1); only used in single-user mode (not with `EXTERNAL_CONF`) |
-| `EXTRA_SHARE_<N>_PATH` | _not set_ | Path for the additional share identified by `EXTRA_SHARE_<N>_NAME` |
+| `EXTRA_SHARES` | _not set_ | Comma-separated list of additional non-Time Machine shares in `name:/path` format (e.g. `Files:/opt/files,Docs:/opt/docs`); only used in single-user mode (not with `EXTERNAL_CONF`) |
 
 ### Adding Extra Non-Time Machine Shares (without EXTERNAL_CONF)
 
-If you want to expose one or more regular file shares alongside your Time Machine share, you can use the `EXTRA_SHARE_<N>_NAME` and `EXTRA_SHARE_<N>_PATH` environment variables instead of setting up `EXTERNAL_CONF` files. This is especially useful for container orchestrators (Portainer, Runtipi, etc.) where shipping config files alongside the container is awkward.
+If you want to expose one or more regular file shares alongside your Time Machine share, you can use the `EXTRA_SHARES` environment variable instead of setting up `EXTERNAL_CONF` files. This is especially useful for container orchestrators (Portainer, Runtipi, etc.) where shipping config files alongside the container is awkward.
 
-The numbering starts at 1 and must be sequential (the loop stops at the first missing `_NAME`).
+> [!NOTE]
+> Each extra share is accessible only to the user defined by `TM_USERNAME`. There is no way to set a different `valid users` per extra share in this mode — use `EXTERNAL_CONF` if you need per-share user control.
 
 #### Example docker-compose with an extra share
 
@@ -242,8 +242,7 @@ services:
       - PASSWORD=timemachine
       - SHARE_NAME=TimeMachine
       - VOLUME_SIZE_LIMIT=512000
-      - EXTRA_SHARE_1_NAME=Files
-      - EXTRA_SHARE_1_PATH=/opt/files
+      - EXTRA_SHARES=Files:/opt/files
     volumes:
       - /path/to/timemachine:/opt/timemachine
       - /path/to/files:/opt/files
@@ -255,6 +254,8 @@ services:
         soft: 65536
         hard: 65536
 ```
+
+Multiple extra shares can be added as a comma-separated list: `EXTRA_SHARES=Files:/opt/files,Docs:/opt/docs`
 
 ### Adding Multiple Users & Shares
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -308,7 +308,7 @@ then
     create_smb_user
 
     # Process extra non-Time Machine shares from EXTRA_SHARES (comma-separated name:path pairs)
-    if [ -n "${EXTRA_SHARES}" ]; then
+    if [ "${CUSTOM_SMB_CONF}" != "true" ] && [ -n "${EXTRA_SHARES}" ]; then
       OLD_IFS="${IFS}"
       IFS=','
       for entry in ${EXTRA_SHARES}; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -307,29 +307,34 @@ then
     # EXTERNAL_CONF not set; assume we are creating one user; create user
     create_smb_user
 
-    # Process extra non-Time Machine shares from environment variables
-    i=1
-    while true; do
-      eval EXTRA_NAME="\$EXTRA_SHARE_${i}_NAME"
-      eval EXTRA_PATH="\$EXTRA_SHARE_${i}_PATH"
-      [ -z "${EXTRA_NAME}" ] && break
+    # Process extra non-Time Machine shares from EXTRA_SHARES (comma-separated name:path pairs)
+    if [ -n "${EXTRA_SHARES}" ]; then
+      OLD_IFS="${IFS}"
+      IFS=','
+      for entry in ${EXTRA_SHARES}; do
+        IFS="${OLD_IFS}"
+        EXTRA_NAME="${entry%%:*}"
+        EXTRA_PATH="${entry#*:}"
 
-      if [ -z "${EXTRA_PATH}" ]; then
-        echo "ERROR: EXTRA_SHARE_${i}_NAME is set but EXTRA_SHARE_${i}_PATH is not; skipping"
-        i=$((i + 1))
-        continue
-      fi
+        if [ -z "${EXTRA_NAME}" ] || [ -z "${EXTRA_PATH}" ] || [ "${EXTRA_NAME}" = "${EXTRA_PATH}" ]; then
+          echo "WARN: invalid EXTRA_SHARES entry '${entry}'; expected format 'name:/path'; skipping"
+          IFS=','
+          continue
+        fi
 
-      echo "INFO: Adding extra share [${EXTRA_NAME}] at ${EXTRA_PATH}"
-      echo "
+        echo "INFO: Adding extra share [${EXTRA_NAME}] at ${EXTRA_PATH}"
+        echo "
 [${EXTRA_NAME}]
    path = ${EXTRA_PATH}
+   inherit permissions = ${SMB_INHERIT_PERMISSIONS}
    read only = no
    valid users = ${TM_USERNAME}
    vfs objects = ${SMB_VFS_OBJECTS}" >> /etc/samba/smb.conf
 
-      i=$((i + 1))
-    done
+        IFS=','
+      done
+      IFS="${OLD_IFS}"
+    fi
   else
     # EXTERNAL_CONF is set; assume we are creating multiple users
     if [ ! -d "${EXTERNAL_CONF}" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -306,6 +306,30 @@ then
 
     # EXTERNAL_CONF not set; assume we are creating one user; create user
     create_smb_user
+
+    # Process extra non-Time Machine shares from environment variables
+    i=1
+    while true; do
+      eval EXTRA_NAME="\$EXTRA_SHARE_${i}_NAME"
+      eval EXTRA_PATH="\$EXTRA_SHARE_${i}_PATH"
+      [ -z "${EXTRA_NAME}" ] && break
+
+      if [ -z "${EXTRA_PATH}" ]; then
+        echo "ERROR: EXTRA_SHARE_${i}_NAME is set but EXTRA_SHARE_${i}_PATH is not; skipping"
+        i=$((i + 1))
+        continue
+      fi
+
+      echo "INFO: Adding extra share [${EXTRA_NAME}] at ${EXTRA_PATH}"
+      echo "
+[${EXTRA_NAME}]
+   path = ${EXTRA_PATH}
+   read only = no
+   valid users = ${TM_USERNAME}
+   vfs objects = ${SMB_VFS_OBJECTS}" >> /etc/samba/smb.conf
+
+      i=$((i + 1))
+    done
   else
     # EXTERNAL_CONF is set; assume we are creating multiple users
     if [ ! -d "${EXTERNAL_CONF}" ]


### PR DESCRIPTION
## Summary

- Add `EXTRA_SHARE_<N>_NAME` and `EXTRA_SHARE_<N>_PATH` environment variables for creating additional non-Time Machine SMB shares purely via env vars, no `EXTERNAL_CONF` files needed
- Supports sequential numbering (`EXTRA_SHARE_1_*`, `EXTRA_SHARE_2_*`, etc.) with error handling for missing paths
- Update README with variable documentation and a docker-compose example

## Motivation

Relates to #73, #9, and #18. Builds on #199 (`TM_ENABLED`).

The use case is: **Time Machine + one or more file shares via pure env vars, no EXTERNAL_CONF files needed.** This is especially useful for container orchestrators (Portainer, Runtipi, etc.) where shipping config files alongside the container is awkward. With `TM_ENABLED` from #199 and this PR, users can set up a Time Machine share plus regular file shares entirely through environment variables.

## Example

```yaml
services:
  timemachine:
    image: mbentley/timemachine:smb
    network_mode: host
    environment:
      - TM_USERNAME=timemachine
      - PASSWORD=timemachine
      - SHARE_NAME=TimeMachine
      - VOLUME_SIZE_LIMIT=512000
      - EXTRA_SHARE_1_NAME=Files
      - EXTRA_SHARE_1_PATH=/opt/files
    volumes:
      - /path/to/timemachine:/opt/timemachine
      - /path/to/files:/opt/files
    tmpfs:
      - /run/samba
```

## Details

- Only applies in single-user mode (non-`EXTERNAL_CONF` path); when using `EXTERNAL_CONF`, users already have full control via `.conf` files (and with `TM_ENABLED` from #199, they can create non-TM shares there)
- Extra shares inherit `valid users` and `vfs objects` from the main share config
- Backward compatible — no behavior changes when the new env vars are not set
- ~15 lines of shell code in `entrypoint.sh`

## Test plan

- [ ] Run container with no `EXTRA_SHARE_*` vars — verify existing behavior unchanged
- [ ] Run with `EXTRA_SHARE_1_NAME=Files` and `EXTRA_SHARE_1_PATH=/opt/files` — verify share appears in `smb.conf`
- [ ] Run with `EXTRA_SHARE_1_NAME=Files` but no `EXTRA_SHARE_1_PATH` — verify error message and share is skipped
- [ ] Run with multiple extra shares (`EXTRA_SHARE_1_*`, `EXTRA_SHARE_2_*`) — verify both appear
- [ ] Verify extra shares are accessible from macOS Finder

🤖 Generated with [Claude Code](https://claude.com/claude-code)